### PR TITLE
Make fall back logic consistent with skip logic

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -177,14 +177,13 @@ def transcribe(
 
     def result_seems_silent(result: DecodingResult) -> bool:
         """Check for no voice activity"""
-        seems_silent = False
-        if no_speech_threshold is not None:
-            seems_silent = result.no_speech_prob > no_speech_threshold
-            if logprob_threshold is not None and result.avg_logprob > logprob_threshold:
-                # don't skip if the logprob is high enough, despite the no_speech_prob
-                seems_silent = False
+        # don't skip if the logprob is high enough, despite the no_speech_prob
+        if no_speech_threshold is not None and (
+            logprob_threshold is None or result.avg_logprob <= logprob_threshold
+        ):
+            return result.no_speech_prob > no_speech_threshold
 
-        return seems_silent
+        return False
 
     def decode_with_fallback(segment: torch.Tensor) -> DecodingResult:
         temperatures = (

--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -177,13 +177,12 @@ def transcribe(
 
     def result_seems_silent(result: DecodingResult) -> bool:
         """Check for no voice activity"""
-        # don't skip if the logprob is high enough, despite the no_speech_prob
-        if no_speech_threshold is not None and (
-            logprob_threshold is None or result.avg_logprob <= logprob_threshold
-        ):
-            return result.no_speech_prob > no_speech_threshold
-
-        return False
+        return (
+            no_speech_threshold is not None
+            and result.no_speech_prob > no_speech_threshold
+            # don't skip if the logprob is high enough, despite the no_speech_prob
+            and (logprob_threshold is None or result.avg_logprob <= logprob_threshold)
+        )
 
     def decode_with_fallback(segment: torch.Tensor) -> DecodingResult:
         temperatures = (


### PR DESCRIPTION
### Background
Currently, `transcribe()` will [choose not to fall back if it believes the segment is silent](https://github.com/openai/whisper/blob/ba3f3cd54b0e5b8ce1ab3de13e32122d0d5f98ab/whisper/transcribe.py#L208-L212), even when it otherwise would (especially due to bad compression).
However, later, it preserves those segments, despite the bad compression, [if the `logprob` is acceptable](https://github.com/openai/whisper/blob/ba3f3cd54b0e5b8ce1ab3de13e32122d0d5f98ab/whisper/transcribe.py#L282-L294).

### What changed
This PR updates `transcribe()` so that only segments that will be skipped are ignored by the fallback logic.