### PR TITLE
Add carry_initial_prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ thumbs.db
 .DS_Store
 .idea
 
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ thumbs.db
 .DS_Store
 .idea
 
-.venv

--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -46,6 +46,7 @@ def transcribe(
     no_speech_threshold: Optional[float] = 0.6,
     condition_on_previous_text: bool = True,
     initial_prompt: Optional[str] = None,
+    carry_initial_prompt: bool = False,
     word_timestamps: bool = False,
     prepend_punctuations: str = "\"'“¿([{-",
     append_punctuations: str = "\"'.。,，!！?？:：”)]}、",
@@ -101,6 +102,11 @@ def transcribe(
         Optional text to provide as a prompt for the first window. This can be used to provide, or
         "prompt-engineer" a context for transcription, e.g. custom vocabularies or proper nouns
         to make it more likely to predict those word correctly.
+
+    carry_initial_prompt: bool
+        If carry_initial_prompt is True, `initial_prompt` is prepended to the prompt of each internal
+        `decode()` call. If there is not enough context space at the start of the prompt, it is
+        left-sliced to make space.
 
     decode_options: dict
         Keyword arguments to construct `DecodingOptions` instances
@@ -227,9 +233,11 @@ def transcribe(
     all_segments = []
     prompt_reset_since = 0
 
+    remaining_prompt_length = model.dims.n_text_ctx // 2 - 1
     if initial_prompt is not None:
         initial_prompt_tokens = tokenizer.encode(" " + initial_prompt.strip())
         all_tokens.extend(initial_prompt_tokens)
+        remaining_prompt_length -= len(initial_prompt_tokens)
     else:
         initial_prompt_tokens = []
 
@@ -275,7 +283,13 @@ def transcribe(
             segment_duration = segment_size * HOP_LENGTH / SAMPLE_RATE
             mel_segment = pad_or_trim(mel_segment, N_FRAMES).to(model.device).to(dtype)
 
-            decode_options["prompt"] = all_tokens[prompt_reset_since:]
+            prompt_reseed = all_tokens[prompt_reset_since:]
+            if carry_initial_prompt:
+                prompt_reseed = (
+                    initial_prompt_tokens + prompt_reseed[-remaining_prompt_length:]
+                )
+            decode_options["prompt"] = prompt_reseed
+
             result: DecodingResult = decode_with_fallback(mel_segment)
             tokens = torch.tensor(result.tokens)
 
@@ -529,6 +543,8 @@ def cli():
 
     parser.add_argument("--suppress_tokens", type=str, default="-1", help="comma-separated list of token ids to suppress during sampling; '-1' will suppress most special characters except common punctuations")
     parser.add_argument("--initial_prompt", type=str, default=None, help="optional text to provide as a prompt for the first window.")
+    parser.add_argument("--carry_initial_prompt", type=str2bool, default=False, help="if True, prepend initial_prompt to every internal decode() call. May reduce the effectiveness of condition_on_previous_text")
+
     parser.add_argument("--condition_on_previous_text", type=str2bool, default=True, help="if True, provide the previous output of the model as a prompt for the next window; disabling may make the text inconsistent across windows, but the model becomes less prone to getting stuck in a failure loop")
     parser.add_argument("--fp16", type=str2bool, default=True, help="whether to perform inference in fp16; True by default")
 

--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -283,12 +283,12 @@ def transcribe(
             segment_duration = segment_size * HOP_LENGTH / SAMPLE_RATE
             mel_segment = pad_or_trim(mel_segment, N_FRAMES).to(model.device).to(dtype)
 
-            prompt_reseed = all_tokens[prompt_reset_since:]
             if carry_initial_prompt:
-                prompt_reseed = (
-                    initial_prompt_tokens + prompt_reseed[-remaining_prompt_length:]
-                )
-            decode_options["prompt"] = prompt_reseed
+                nignored = max(len(initial_prompt_tokens), prompt_reset_since)
+                remaining_prompt = all_tokens[nignored:][-remaining_prompt_length:]
+                decode_options["prompt"] = initial_prompt_tokens + remaining_prompt
+            else:
+                decode_options["prompt"] = all_tokens[prompt_reset_since:]
 
             result: DecodingResult = decode_with_fallback(mel_segment)
             tokens = torch.tensor(result.tokens)


### PR DESCRIPTION
**Background**
Whisper's `transcribe()` struggles with contextual proper nouns if they appear after the initial prompt has been consumed; see some experimental results [here](https://github.com/openai/whisper/discussions/1824#discussioncomment-7631300). This solves that issue by allowing the initial "context" prompt to be carried as the sliding window moves through the audio.

**Changes**
Add an option `carry_initial_prompt = False` to `whisper.transcribe()`.

When `carry_initial_prompt` is set to `True`, `initial_prompt` is prepended to each internal `decode()` call's `prompt`. If there is not enough context space at the start of the prompt, the prompt is left-sliced to make space.